### PR TITLE
feature/handle-different-environments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY app/ .
 RUN go mod download
 
 # 5. Build the Go binary
-RUN go build -o myfoodapplicaton_homelab
+RUN go build -o myfoodapplication_homelab
 
 # 6. Final stage: use minimal base image to run the binary
 FROM alpine:latest
@@ -20,11 +20,10 @@ FROM alpine:latest
 WORKDIR /app
 
 # 8. Copy the binary from builder stage
-COPY --from=builder /app/myfoodapplicaton_homelab .
-COPY --from=builder /app/.env .
+COPY --from=builder /app/myfoodapplication_homelab .
 
 # 9. Document the port the app listens on
 EXPOSE 8080
 
 # 10. Set default command to run
-CMD ["./myfoodapplicaton_homelab"]
+CMD ["./myfoodapplication_homelab"]

--- a/app/config/db.go
+++ b/app/config/db.go
@@ -2,23 +2,14 @@ package config
 
 import (
 	"database/sql"
-	"log"
 	"os"
 	"fmt"
-
-	"github.com/joho/godotenv"
 	_ "github.com/lib/pq"
 )
 
 var DB *sql.DB
 
 func ConnectDB() error {
-	// Load .env file
-	err := godotenv.Load(".env")
-	if err != nil{
-		log.Fatalf("Error loading .env file. Detail: %s", err.Error())
-	}
-
 	// Get values from environment
 	host := os.Getenv("DB_HOST")
 	port := os.Getenv("DB_PORT")


### PR DESCRIPTION
Modified:

- Removed reading-env-file code to:
- Avoid using .env file for application for the sake of security - as we don't have .env file in our repo.
- Handle specific environment's variable value in Docker/K8S 